### PR TITLE
fix: Fix content type

### DIFF
--- a/urlmatcher.py
+++ b/urlmatcher.py
@@ -52,8 +52,12 @@ class UrlMatcher(BotPlugin):
 
         # ignore anything that is not allowed in configuration
         allowed_content_types = self.config['ALLOWED_CONTENT_TYPES']
-        if 'content-type' in r.headers and \
-           r.headers['content-type'] not in allowed_content_types:
+        content_type = ''
+        if 'content-type' in r.headers:
+            content_type = re.sub(r'\s*\;.*$', '', r.headers['content-type'])
+            content_type = content_type.strip()
+
+        if content_type in allowed_content_types:
             return
 
         html = requests.get(url).text


### PR DESCRIPTION
- Given the current state of the internet, content-type many times looks
  like the following:
  
  ```
     text/html; charset=UTF-8
  ```
  
  This commit strips everything after `;`.

Signed-off-by: mr.Shu mr@shu.io
