### PR TITLE
update: Use title instead of short_title

### DIFF
--- a/urlmatcher.py
+++ b/urlmatcher.py
@@ -67,7 +67,7 @@ class UrlMatcher(BotPlugin):
         if len(readable_article) > max_len:
             readable_article = readable_article[:max_len] + '...'
 
-        readable_title = Document(html).short_title()
+        readable_title = Document(html).title()
 
         page = MetadataParser(html=html)
         readable_description = page.get_metadata('description')


### PR DESCRIPTION
- While the readability package shows mostly the `short_title` function,
  this is not always desirable, especially when the urlmatcher's task is
  to provide as much information on the URL as possible.
  
  This commit therefore makes use of `short_title` rather than `title`.

Signed-off-by: mr.Shu mr@shu.io
